### PR TITLE
Add TypeScript definitions

### DIFF
--- a/scripts/build-core.js
+++ b/scripts/build-core.js
@@ -15,7 +15,11 @@ var fs = require("fs"),
 	LIB_SRC = path.join(SRC_DIR,"fasy.src.js"),
 	LIB_DIST = path.join(DIST_DIR,"fasy.js"),
 
-	result
+	TYPES_SRC = path.join(SRC_DIR,"fasy.src.d.ts"),
+	TYPES_DIST = path.join(DIST_DIR,"fasy.d.ts"),
+
+	jsFile,
+	tsFile
 ;
 
 console.log("*** Building Core ***");
@@ -29,9 +33,9 @@ try {
 	catch (err) { }
 
 	// NOTE: since uglify doesn't yet support ES6, no minifying happening :(
-	result = fs.readFileSync(LIB_SRC,{ encoding: "utf8" });
+	jsFile = fs.readFileSync(LIB_SRC,{ encoding: "utf8" });
 
-	// result = ugly.minify(path.join(SRC_DIR,"fasy.src.js"),{
+	// jsFile = ugly.minify(path.join(SRC_DIR,"fasy.src.js"),{
 	// 	mangle: {
 	// 		keep_fnames: true
 	// 	},
@@ -60,10 +64,15 @@ try {
 	copyrightHeader = Function("version","year",`return \`${copyrightHeader}\`;`)( version, year );
 
 	// append copyright-header text
-	result = copyrightHeader + result;
+	jsFile = copyrightHeader + jsFile;
 
 	// write dist
-	fs.writeFileSync( LIB_DIST, result /* result.code + "\n" */, { encoding: "utf8" } );
+	fs.writeFileSync( LIB_DIST, jsFile /* jsFile.code + "\n" */, { encoding: "utf8" } );
+
+	// same thing for TypeScript definitions
+	tsFile = fs.readFileSync(TYPES_SRC,{ encoding: "utf8" });
+	tsFile = copyrightHeader + tsFile;
+	fs.writeFileSync( TYPES_DIST, tsFile, { encoding: "utf8" } );
 
 	console.log("Complete.");
 }

--- a/src/fasy.src.d.ts
+++ b/src/fasy.src.d.ts
@@ -1,0 +1,80 @@
+export declare type PotentialPromise<T> = T | Promise<T>;
+export declare type MapperFn<I, O> = (
+  value: I,
+  idx: number,
+  arr: I[]
+) => PotentialPromise<O>;
+export declare type EachFn<I> = MapperFn<I, any>;
+export declare type PredicateFn<I> = MapperFn<I, any>;
+export declare type ReducerFn<I, O> = (
+  acc: O,
+  v: I,
+  idx: number,
+  arr: I[]
+) => Promise<O>;
+export declare type Transducer<I, O> = (
+  combinationFn: ReducerFn<I, O>
+) => ReducerFn<I, O>;
+
+export declare namespace concurrent {
+  function forEach<I>(eachFn: EachFn<I>, arr?: I[]): Promise<void>;
+  function map<I, O>(mapperFn: MapperFn<I, O>, arr?: I[]): Promise<O[]>;
+  function flatMap<I, O>(mapperFn: MapperFn<I, O>, arr?: I[]): Promise<O[]>;
+  function filterIn<I>(predicateFn: PredicateFn<I>, arr?: I[]): Promise<I[]>;
+  function filterOut<I>(predicateFn: PredicateFn<I>, arr?: I[]): Promise<I[]>;
+  const filter: typeof filterIn;
+}
+
+export declare namespace serial {
+  function forEach<I>(eachFn: EachFn<I>, arr?: I[]): Promise<void>;
+  function map<I, O>(mapperFn: MapperFn<I, O>, arr?: I[]): Promise<O[]>;
+  function flatMap<I, O>(mapperFn: MapperFn<I, O>, arr?: I[]): Promise<O[]>;
+  function filterIn<I>(predicateFn: PredicateFn<I>, arr?: I[]): Promise<I[]>;
+  function filterOut<I>(predicateFn: PredicateFn<I>, arr?: I[]): Promise<I[]>;
+  const filter: typeof filterIn;
+  function reduce<I, O>(
+    reducerFn: ReducerFn<I, O>,
+    initial: O,
+    arr?: I[]
+  ): Promise<O>;
+  function reduceRight<I, O>(
+    reducerFn: ReducerFn<I, O>,
+    initial: O,
+    arr?: I[]
+  ): Promise<O>;
+  function pipe(fns?: ((..._: any[]) => any)[]): (..._: any[]) => any;
+  function compose(fns?: ((..._: any[]) => any)[]): (..._: any[]) => any;
+}
+
+export declare namespace concurrent {
+  const reduce: typeof serial.reduce;
+  const reduceRight: typeof serial.reduceRight;
+  const pipe: typeof serial.pipe;
+  const compose: typeof serial.compose;
+}
+
+export declare namespace transducers {
+  function filter<I, O>(
+    predicateFn: PredicateFn<I>
+  ): (combinationFn: ReducerFn<I, O>) => ReducerFn<I, O>;
+  function map<I, O>(
+    mapperFn: MapperFn<I, O>
+  ): (combinationFn: ReducerFn<I, O>) => ReducerFn<I, O>;
+  function transduce<I, O>(
+    transducer: Transducer<I, O>,
+    combinationFn: ReducerFn<I, O>,
+    initialValue: O,
+    arr?: I[]
+  ): Promise<O>;
+  function into<I>(
+    transducer: Transducer<I, I>,
+    initialValue: I,
+    arr?: I[]
+  ): Promise<I>;
+  function string(acc: string, v: string): string;
+  function number(acc: number, v: number): number;
+  function booleanAnd(acc: boolean, v: boolean): boolean;
+  function booleanOr(acc: boolean, v: boolean): boolean;
+  function array<I>(acc: I[], v: I): I[];
+  function noop<I>(acc: I, v: I): I;
+}


### PR DESCRIPTION
A couple of notes:
- I left PredicateFn's eventual return type as `any` as it didn't seem necessary to restrict it to `boolean` (I could be convinced either way)
- I don't think these definitions would work for generator functions, which I'm not familiar enough with. I suspect this could be fixed by changing `PotentialPromise` to `T | Promise<T> | Iterable<PotentialPromise<T>>` although this would restrict every yield to type `T`, when we only care about the very last value being of type `T`.

It's also highly possible that I misunderstood transducers, as I'm having trouble wrapping my head around the concept.

Let me know what you think, thanks!